### PR TITLE
Adds CartoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Bluespark | https://www.bluespark.com/
 buffer | https://buffer.com/
 Canonical | http://www.canonical.com/
 Cards Against Humanity | https://cardsagainsthumanity.com/
+CartoDB | https://cartodb.com/
 Catalyze | https://catalyze.io/
 charity: water | http://www.charitywater.org/
 Chef | http://chef.io/


### PR DESCRIPTION
This PR adds `cartodb.com` to the list. An example of a remote job offer: https://cartodb.com/jobs/junior-designer.