### PR TITLE
Add GitHub company profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Functionite | http://functionite.com/ | |
 General Assembly | http://generalassemb.ly | |
 Ghost | https://ghost.org/ | |
 Gitbook | https://www.gitbook.com/ | |
-GitHub | https://github.com/ | |
+GitHub | https://github.com/ | Everywhere | [Profile](/company-profiles/github.md)
 GitLab | https://about.gitlab.com/ | |
 Glue Networks | http://gluenetworks.com/ | |
 Google | https://www.google.com/ | |

--- a/company-profiles/github.md
+++ b/company-profiles/github.md
@@ -1,0 +1,38 @@
+# GitHub
+
+## Company blurb
+
+GitHub is how people build software. With a community of more than 11 million people, developers can discover, use, and contribute to over 28 million projects using a powerful collaborative development workflow.
+
+Come help us make collaboration even better. At GitHub we build the tools that make collaborating and writing software easier. We’ve built a company we truly love working for, and we think you will too. [Here’s why](https://github.com/about/jobs).
+
+## Company size
+
+Around 400 employees.
+
+## Remote status
+
+Our flagship office is located in San Francisco, CA, but we have employees all over the world. We communicate through GitHub, Campfire, e-mail, and our own internal apps.
+
+## Region
+
+We have employees in almost every time zone in the world! From San Francisco to London to Australia, we hire people regardless of their physical location. We even have nomadic employees!
+
+## Company technologies
+
+- Ruby on Rails
+- MySQL
+- CoffeeScript
+- SASS
+- Git
+
+## Office Locations
+
+- San Francisco, CA
+- Boulder, CO
+- Portland, OR
+- Tokyo, Japan
+
+## How to apply
+
+Apply for any of the jobs listed on [our Jobs page](https://github.com/about/jobs)!


### PR DESCRIPTION
This branch adds a company profile for GitHub and fills out the empty columns in the GitHub row of the README!

:heart::yellow_heart::green_heart::blue_heart::purple_heart: