### PR TITLE
Remove "Wordpress" from company list

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,6 @@ Whitespectre | http://whitespectre.com |
 WikiHow | http://www.wikihow.com/wikiHow:About-wikiHow | PST Timezone
 Wikimedia | https://commons.wikimedia.org/wiki/Main_Page |
 Word to the Wise | https://wordtothewise.com |
-Wordpress | https://wordpress.com/ |
 X-Team | http://x-team.com/ |
 YouCanBook.me Ltd | https://youcanbook.me |
 Zapier | https://zapier.com/ |


### PR DESCRIPTION
wordpress.com is run by Automattic (already on the list) and isn't a separate company.
WordPress, however, is fantastic software built buy hundreds of volunteers from around the world. :D