### PR TITLE
Add Hack Reactor Remote Beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ GoHiring | http://www.gohiring.com/ | Worldwide
 GotSoccer, LLC | http://www.gotsoccerpro.com |
 Graylog | https://www.graylog.org/ |
 [Gridium](/company-profiles/gridium.md) | http://gridium.com | US
+[Hack Reactor Remote](/company-profiles/hackreactorremote.md) | http://www.hackreactor.com/remote-beta/ | Pacific Time Zone (PT)
 Haiku Learning | http://www.haikulearning.com/ |
 Hanno | https://hanno.co/ |
 Happy Cog | http://happycog.com/ | USA

--- a/company-profiles/hackreactorremote.md
+++ b/company-profiles/hackreactorremote.md
@@ -1,0 +1,47 @@
+# Hack Reactor Remote
+
+## Company blurb
+
+Hack Reactor Remote is a program for gifted students of software engineering.
+In three months, we transform ambitious amateurs to coding professionals.
+95% of our US graduates are now working as software engineers, at a
+country-wide average salary of $93k.
+
+Hack Reactor Remote's mission is twofold: to empower people and to transform
+education through rapid-iteration teaching. We are the premier advanced
+distributed immersive that trains exceptional full-stack Software Engineers.
+Students train 11 hours a day, 6 days a week, over 12 weeks in a curriculum
+focused on computer science fundamentals and JavaScript.
+
+Employees enjoy a fun, collegial startup environment genuinely committed to
+employee health and wellness, and filled with talented, hard-working and fun
+people. You will be surrounded by friendly, brilliant, and mission-driven
+professionals who work hard to provide the best student experience of its
+kind in the world.
+
+## Company size
+
+Approximate size: 20-50
+
+## Remote status
+
+Staff members must be able to work 9am-6pm Pacific Time Zone and
+non-traditional hours as necessary.
+
+## Region
+
+Currently, our full-time staff is based entirely in the United States.
+
+## Company technologies
+
+Asana, GitHub, Google Drive, Slack, Zoom
+
+## Office Locations
+
+944 Market St, San Francisco, CA 94102
+
+## How to apply
+
+Check our [careers page](http://www.hackreactor.com/careers) for
+`[Remote Beta]` listings! Most positions will include the option to work
+remotely.


### PR DESCRIPTION
Hack Reactor Remote Beta is a 3-month coding bootcamp that trains software engineers in a remote environment. **Hack Reactor Remote Beta also hires remote employees!**

I listed "Pacific Time Zone (PT)," as it is the generic, official name that covers both PST and PDT.
https://en.wikipedia.org/wiki/Pacific_Time_Zone