### PR TITLE
SocialBro now is Audiense

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Arkency | http://arkency.com/ |
 [Artefactual Systems](/company-profiles/artefactual.md) | https://www.artefactual.com | UTC-8 to UTC+2
 [Articulate](/company-profiles/articulate.md) | https://www.articulate.com | Worldwide
 [Atomic Squirrel](/company-profiles/atomic-squirrel.md) | http://www.atomic-squirrel.net/ | Worldwide
+Audiense | http://www.audiense.com/ |
 [Auth0](/company-profiles/auth0.md) | https://auth0.com/ | Worldwide
 [Automattic](/company-profiles/automattic.md) | https://automattic.com/ | Worldwide
 [Axelerant](/company-profiles/axelerant.md) | https://axelerant.com/ | Worldwide
@@ -228,7 +229,6 @@ SignEasy | http://getsigneasy.com |
 Simple | https://www.simple.com/ |
 Skillshare  | https://www.skillshare.com/teach |
 SmugMug | https://www.smugmug.com/ |
-SocialBro | http://www.socialbro.com/ |
 SoftwareMill | https://softwaremill.com/ |
 Soostone | http://www.soostone.com/ |
 [Spoqa](/company-profiles/spoqa.md) | http://www.spoqa.com/ | South Korea and Japan


### PR DESCRIPTION
This is a modified version of the [Contributing Guidelines](/CONTRIBUTING.md).

This pull request adheres to the repository's [Code of Conduct](/CODE_OF_CONDUCT.md)

- [x] This PR contains housekeeping (URL edits, copy changes etc)
- [x] You know your alphabet - company is listed in alphabetical order in the README
- [x] A company profile is included - Not essential but it really helps!
- [x] The company directly hires employees - This may sounds odd but while awesome, this list is not for coding bootcamps, "teaching" positions a network (Teacher positions employed directly, such as Treehouse, are allowed), or networking sites for listing a CV looking for gigs
- [x] The company added hires remote employees, or positions are available to remote workers and are clearly illustrated as such
- [x] A company-profile has been included for each addition to the list
- [ ] I am an employee of the company mentioned and confirm all details are correct
- [x] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
- [x] __Region__ details any restrictions to applicants based on geography
- [x] __How to apply__ details the best approach for new applications, link to open positions, and any other help available for job hunters
- [ ] Any missing parts from the profile, please use \<Unknown\> to allow for future completion

SocialBro have changed their name, now they call Audiense. I'm not an employee actually but I have been in the past.