### PR TITLE
Add helabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ HashiCorp | https://www.hashicorp.com/ |
 Healthfinch | http://www.healthfinch.com/ |
 Heap | https://heapanalytics.com/ | Worldwide
 Help Scout | https://www.helpscout.net/ |
+[HE:labs](/company-profiles/helabs.md) | https://www.helabs.com | Worldwide, Office in Rio, BRAZIL
 Heroku | https://www.heroku.com/ |
 [Hireology](/company-profiles/hireology.md) | https://www.hireology.com | United States
 Honeybadger | https://www.honeybadger.io/ |

--- a/company-profiles/helabs.md
+++ b/company-profiles/helabs.md
@@ -1,0 +1,29 @@
+# HE:labs
+
+## Company blurb
+
+We are a team of agile designers and developers, and we can turn your idea into a great digital product!. Let's do something special together.
+
+## Company size
+
+50+
+
+## Remote status
+
+100% Remote. We also have a beatifull office in (Rio)[https://journal.helabs.com/what-if-your-company-takes-you-to-rio-de-janeiro-966e9ec4a1aa#.20slfxsp2]
+
+## Region
+
+Worldwide
+
+## Company technologies
+
+Ruby, Clojure, Elixir, JavaScript, HTML5, CSS3, Postgres, Heroku, AWS, GCE, Docker, Kubernetes
+
+## Office Locations
+
+Rio de Janeiro, BRA
+
+## How to apply
+
+HE:labs have a [careers page](https://helabs.com/br/trabalhe-conosco)


### PR DESCRIPTION
Adding HE:labs to this awesome list 😄 

This pull request adheres to the repository's [Code of Conduct](/CODE_OF_CONDUCT.md)
- [X] You know your alphabet - company is listed in alphabetical order in the README
- [X] A company profile is included - Not essential but it really helps!
- [X] The company directly hires employees - This may sounds odd but while awesome, this list is not for coding bootcamps, "teaching" positions a network (Teacher positions employed directly, such as Treehouse, are allowed), or networking sites for listing a CV looking for gigs
- [X] The company added hires remote employees, or positions are available to remote workers and are clearly illustrated as such
- [X] A company-profile has been included for each addition to the list
- [X] I am an employee of the company mentioned and confirm all details are correct
- [X] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
- [X] __Region__ details any restrictions to applicants based on geography
- [X] __How to apply__ details the best approach for new applications, link to open positions, and any other help available for job hunters