### PR TITLE
add the grid profile and edit existing readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Teleport | http://teleport.org/ |
 Telerik | http://www.telerik.com/ |
 Tenable | http://www.tenable.com/ |
 Test Double | http://testdouble.com/ |
-The Grid | https://thegrid.io/ |
+The Grid | https://thegrid.io/ | Worldwide
 The Publisher Desk | http://www.publisherdesk.com |
 The Remote Lab | http://theremotelab.io |
 [The Wirecutter](/company-profiles/the-wirecutter.md) | http://thewirecutter.com/ | Worldwide

--- a/company-profiles/thegrid.md
+++ b/company-profiles/thegrid.md
@@ -1,0 +1,25 @@
+# The Grid
+
+## Company blurb
+The Grid is an AI website builder. User's can upload content and the AI will
+create a beautiful site based on the content provided.
+
+[The Grid](http://thegrid.io).
+
+## Company size
+<20
+
+## Remote status
+The Grid is a 100% remote team.
+
+## Region
+Worldwide
+
+## Company technologies
+React, Inferno, iOS, Android
+
+## Office Locations
+SF and Berlin
+
+## How to apply
+You can apply by sending your details (CV, motivation, open source, stackoverflow, etc.) to support@thegrid.io


### PR DESCRIPTION
This PR adds The Grid's company profile, and adds the region to the existing readme file.

- [X] This PR contains housekeeping (URL edits, copy changes etc)
- [X] You know your alphabet - company is listed in alphabetical order in the README
- [X] A company profile is included - Not essential but it really helps!
- [X] The company directly hires employees - This may sounds odd but while awesome, this list is not for coding bootcamps, "teaching" positions a network (Teacher positions employed directly, such as Treehouse, are allowed), or networking sites for listing a CV looking for gigs
- [X] The company added hires remote employees, or positions are available to remote workers and are clearly illustrated as such
- [X] A company-profile has been included for each addition to the list
- [X] I am an employee of the company mentioned and confirm all details are correct
- [X] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
- [X] __Region__ details any restrictions to applicants based on geography
- [X] __How to apply__ details the best approach for new applications, link to open positions, and any other help available for job hunters
- [ ] Any missing parts from the profile, please use \<Unknown\> to allow for future completion
