### PR TITLE
Add Getaround and edit the Grid company profile link

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Teleport | http://teleport.org/ |
 Telerik | http://www.telerik.com/ |
 Tenable | http://www.tenable.com/ |
 Test Double | http://testdouble.com/ |
-The Grid | https://thegrid.io/ |
+The Grid | https://thegrid.io/ | Worldwide
 The Publisher Desk | http://www.publisherdesk.com |
 The Remote Lab | http://theremotelab.io |
 [The Wirecutter](/company-profiles/the-wirecutter.md) | http://thewirecutter.com/ | Worldwide

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Fuel Made | http://fuelmade.com/ |
 [FullFabric](/company-profiles/fullfabric.md) | http://fullfabric.com/ | Europe
 Functionite | http://functionite.com/ |
 General Assembly | https://generalassemb.ly/ |
+[Getaround](/company-profiles/getaround.md) | http://getaround.com | US, Canada
 [Ghost Foundation](/company-profiles/ghost.md) | https://ghost.org/ | Worldwide
 Giant Swarm | https://giantswarm.io | Worldwide
 [GigSalad](/company-profiles/gigsalad.md) | https://www.gigsalad.com/ | US
@@ -294,7 +295,7 @@ Teleport | http://teleport.org/ |
 Telerik | http://www.telerik.com/ |
 Tenable | http://www.tenable.com/ |
 Test Double | http://testdouble.com/ |
-The Grid | https://thegrid.io/ | Worldwide
+[The Grid](/company-profiles/thegrid.md)  | https://thegrid.io/ | Worldwide
 The Publisher Desk | http://www.publisherdesk.com |
 The Remote Lab | http://theremotelab.io |
 [The Wirecutter](/company-profiles/the-wirecutter.md) | http://thewirecutter.com/ | Worldwide

--- a/company-profiles/getaround.md
+++ b/company-profiles/getaround.md
@@ -1,0 +1,35 @@
+# Getaround
+
+## Company blurb
+
+Getaround is a peer-to-peer carsharing company. Owners can list their car to
+rent, and renters can use a mobile device to rent and unlock cars listed on
+the platform.
+
+[Getaround](http://www.getaround.com).
+
+## Company size
+
+75-100 employees
+
+## Remote status
+
+The majority of the team is out of the SF office. However, a small percentage
+of the company is remote full time. Although they would rather have team members
+on location, they will allow 100% remote for the right candidates.
+
+## Region
+
+US and Canada only.
+
+## Company technologies
+
+iOS, Android and web applications
+
+## Office Locations
+
+HQ is located in SOMA area of San Francisco, CA.
+
+## How to apply
+
+[Getaround jobs page](http://www.getaround.com/jobs).

--- a/company-profiles/thegrid.md
+++ b/company-profiles/thegrid.md
@@ -1,0 +1,25 @@
+# The Grid
+
+## Company blurb
+The Grid is an AI website builder. User's can upload content and the AI will
+create a beautiful site based on the content provided.
+
+[The Grid](http://thegrid.io).
+
+## Company size
+<20
+
+## Remote status
+The Grid is a 100% remote team.
+
+## Region
+Worldwide
+
+## Company technologies
+React, Inferno, iOS, Android
+
+## Office Locations
+SF and Berlin
+
+## How to apply
+You can apply by sending your details (CV, motivation, open source, stackoverflow, etc.) to support@thegrid.io


### PR DESCRIPTION
This is a modified version of the [Contributing Guidelines](/CONTRIBUTING.md).

This pull request adheres to the repository's [Code of Conduct](/CODE_OF_CONDUCT.md)

- [X] This PR contains housekeeping (URL edits, copy changes etc)
- [X] You know your alphabet - company is listed in alphabetical order in the README
- [X] A company profile is included - Not essential but it really helps!
- [X] The company directly hires employees - This may sounds odd but while awesome, this list is not for coding bootcamps, "teaching" positions a network (Teacher positions employed directly, such as Treehouse, are allowed), or networking sites for listing a CV looking for gigs
- [X] The company added hires remote employees, or positions are available to remote workers and are clearly illustrated as such
- [X] A company-profile has been included for each addition to the list
- [X] I was an employee of the company mentioned and confirm all details are correct
- [X] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
- [X] __Region__ details any restrictions to applicants based on geography
- [X] __How to apply__ details the best approach for new applications, link to open positions, and any other help available for job hunters
- [ ] Any missing parts from the profile, please use \<Unknown\> to allow for future completion
