### PR TITLE
Add LaterPay company profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ KickBack Rewards Systems | http://careers.kickbacksystems.com |
 [Kissmetrics](/company-profiles/kissmetrics.md) | https://www.kissmetrics.com/ | USA & Worldwide
 [Knack](/company-profiles/knack.md) | https://www.knackhq.com | US
 Koding | https://koding.com | US, Turkey, Denmark, Romania, Russia & Poland
-LaterPay | https://www.laterpay.net/ |
+[LaterPay](/company-profiles/laterpay.md) | https://www.laterpay.net/ |
 Let's Encrypt | https://letsencrypt.org | US and Canada
 Librato | https://www.librato.com/ |
 Lightbend | http://www.lightbend.com/ | Worldwide

--- a/company-profiles/laterpay.md
+++ b/company-profiles/laterpay.md
@@ -1,0 +1,33 @@
+# LaterPay
+
+## Company blurb
+
+LaterPay is a SaaS payment infrastructure that skips upfront registration and payment for paid content and services. Instead, it gets users over the hurdle by aggregating a user’s purchases and charging them later.
+
+Check out our [team](https://www.laterpay.net/team) and [careers](https://www.laterpay.net/careers/) page for more on how we work.
+
+## Company size
+
+40+
+
+See https://www.laterpay.net/team
+
+## Remote status
+
+Around 80% of the team is distributed and a few people work in an office in Munich. We have a remote-first mentality when it comes to our communication, and work mostly in an asychronous way.
+
+## Region
+
+Europe, US, Brazil, Canada. Most of our people are in Europe, so we try to ensure some overlap in terms of timezones.
+
+## Company technologies
+
+Python, Postgres, JS, React.
+
+## Office Locations
+
+Munich (Germany), NY (US)
+
+## How to apply
+
+https://www.laterpay.net/careers


### PR DESCRIPTION
This company was already in the list but with no profile

-----

This is a modified version of the [Contributing Guidelines](/CONTRIBUTING.md).

This pull request adheres to the repository's [Code of Conduct](/CODE_OF_CONDUCT.md)

- [ ] This PR contains housekeeping (URL edits, copy changes etc)
- [ ] You know your alphabet - company is listed in alphabetical order in the README
- [x] A company profile is included - Not essential but it really helps!
- [x] The company directly hires employees - This may sounds odd but while awesome, this list is not for coding bootcamps, "teaching" positions a network (Teacher positions employed directly, such as Treehouse, are allowed), or networking sites for listing a CV looking for gigs
- [x] The company added hires remote employees, or positions are available to remote workers and are clearly illustrated as such
- [ ] A company-profile has been included for each addition to the list
- [x] I am an employee of the company mentioned and confirm all details are correct
- [x] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
- [x] __Region__ details any restrictions to applicants based on geography
- [x] __How to apply__ details the best approach for new applications, link to open positions, and any other help available for job hunters
- [ ] Any missing parts from the profile, please use \<Unknown\> to allow for future completion
